### PR TITLE
Show an intermediate html page before login (fix #71)

### DIFF
--- a/app/src/main/java/in/ac/iitb/gymkhana/iitbapp/LoginActivity.java
+++ b/app/src/main/java/in/ac/iitb/gymkhana/iitbapp/LoginActivity.java
@@ -47,7 +47,7 @@ public class LoginActivity extends AppCompatActivity {
     //TODO: Change this to production before launch
     private final String clientId = "vR1pU7wXWyve1rUkg0fMS6StL1Kr6paoSmRIiLXJ";
     private final Uri redirectUri = Uri.parse("https://redirecturi");
-    private final Uri mAuthEndpoint = Uri.parse("http://gymkhana.iitb.ac.in/sso/oauth/authorize/");
+    private final Uri mAuthEndpoint = Uri.parse("https://temp-iitb.radialapps.com/content/login.html");
     private final Uri mTokenEndpoint = Uri.parse("http://gymkhana.iitb.ac.in/sso/oauth/token/");
     public String authCode = null;
     SessionManager session;


### PR DESCRIPTION
Android doesn't capture intents if the redirect is made without some
user interaction, which includes clicking a button. Currently, if the
user is logged in, the page redirects directly to the redirecturi and
the intent doesn't trigger. Adding this intermediate page ensures that
the user cliicks a button, thus properly triggering the intent.

This is somewhat of a workaround, but works as expected.